### PR TITLE
Do not pollute

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -81,9 +81,9 @@ add_library(${PROJECT_NAME} ${HBKLIB_SOURCES})
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 if(HBK_HARDWARE)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC -D_HBK_HARDWARE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -D_HBK_HARDWARE)
 else()
-    target_compile_definitions(${PROJECT_NAME} PUBLIC -D_STANDARD_HARDWARE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -D_STANDARD_HARDWARE)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/lib/include/hbk/string/trim.h
+++ b/lib/include/hbk/string/trim.h
@@ -28,7 +28,7 @@
 namespace hbk {
 	namespace string {
 		/// Default whitespace characters
-		static const char* trim_ws = " \t\n\r\f\v";
+		static const char trim_ws[] = " \t\n\r\f\v";
 
 		/// right and left trim of default whitespace characters
 		std::string trim_copy(std::string text);

--- a/lib/sys/linux/executecommand.cpp
+++ b/lib/sys/linux/executecommand.cpp
@@ -27,9 +27,6 @@
 #include <string>
 #include <array>
 
-#ifdef _STANDARD_HARDWARE
-	#include <iostream>
-#endif
 #include <stdexcept>
 
 #include <sys/types.h>


### PR DESCRIPTION
Internal compile definitions are not to be exported as interface for those using the library