### PR TITLE
Asan

### DIFF
--- a/lib/sys/linux/executecommand.cpp
+++ b/lib/sys/linux/executecommand.cpp
@@ -26,8 +26,7 @@
 #include <memory>
 #include <string>
 #include <array>
-
-#include <stdexcept>
+#include <vector>
 
 #include <sys/types.h>
 
@@ -50,10 +49,16 @@
 
 namespace hbk {
 	namespace sys {
+		/// Callback for automatic destruction of unique pointer
+		static void closePipe(std::FILE* fp)
+		{
+			pclose(fp);
+		};
+
 		std::string executeCommand(const std::string& command)
 		{
 			std::string retVal;
-			std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
+			std::unique_ptr<FILE, decltype(&closePipe)> pipe(popen(command.c_str(), "r"), closePipe);
 			if (!pipe) {
 				std::string msg = std::string(__FUNCTION__) + "popen failed (cmd=" + command + ")!";
 				throw hbk::exception::exception(msg);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,8 @@ set(INSTALL_GTEST OFF)
 FetchContent_MakeAvailable(googletest)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(ASAN_COMPILE_FLAGS -fsanitize=address -fno-omit-frame-pointer)
+  set(ASAN_LIB asan)
   set(CGOV_COMPILE_FLAGS -fno-omit-frame-pointer -fno-optimize-sibling-calls -ftest-coverage -fprofile-arcs)
   set(GCOV_LINK_FLAGS -fprofile-arcs -ftest-coverage)
   set(GCOV_LIB gcov)
@@ -57,7 +59,10 @@ add_library(testlib OBJECT
     ../lib/sys/linux/executecommand.cpp
 )
 
-target_link_libraries(testlib PUBLIC hbk::hbk)
+target_link_libraries(testlib
+    PUBLIC
+    ${ASAN_LIB}
+    hbk::hbk)
 
 target_compile_options(testlib PRIVATE
  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/test/sys/CMakeLists.txt
+++ b/test/sys/CMakeLists.txt
@@ -41,9 +41,9 @@ get_property(targets DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" PROPERTY BUILDSYSTEM_
 foreach(tgt ${targets})
   get_target_property(target_type ${tgt} TYPE)
   if (target_type STREQUAL "EXECUTABLE")
-    target_link_libraries(${tgt} ${CMAKE_THREAD_LIBS_INIT} testlib GTest::gtest GTest::gtest_main) 
+    target_link_libraries(${tgt} ${ASAN_LIB} testlib GTest::gtest GTest::gtest_main)
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-        target_link_libraries(${tgt} gcov)
+        target_link_libraries(${tgt} ${GCOV_LIB})
     endif()
 
     set_target_properties(${tgt} PROPERTIES


### PR DESCRIPTION
Enable address sanitizer for unit tests

Callback for automatic destruction of unique pointer
